### PR TITLE
remove runhook and remove /tmp from hab command

### DIFF
--- a/controls/bats_works.rb
+++ b/controls/bats_works.rb
@@ -2,7 +2,6 @@ title 'Tests to confirm bats works as expected'
 
 plan_name = input('plan_name', value: 'bats')
 plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-hab_path = input('hab_path', value: '/tmp/hab')
 
 control 'core-plans-bats' do
   impact 1.0
@@ -19,7 +18,7 @@ control 'core-plans-bats' do
     Bats 0.4.0
     ...
   '
-  bats_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  bats_pkg_ident = command("hab pkg path #{plan_ident}")
   describe bats_pkg_ident do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done


### PR DESCRIPTION
Signed-off-by: Steven Marshall <SMarshall@chef.io>
